### PR TITLE
removed line add_header X-Frame-Options "SAMEORIGIN";

### DIFF
--- a/templates/nginx_nc.j2
+++ b/templates/nginx_nc.j2
@@ -36,7 +36,6 @@ server {
 {% endif %}
 {% endif %}
     add_header X-Content-Type-Options nosniff;
-    add_header X-Frame-Options "SAMEORIGIN";
     add_header X-XSS-Protection "1; mode=block";
     add_header X-Robots-Tag none;
     add_header X-Download-Options noopen;


### PR DESCRIPTION
https://help.nextcloud.com/t/x-frame-options-sameorigin-nc-on-nginx-keeps-warning-me/1553
As suggested it says that it is a duplicate.